### PR TITLE
Fix for httpd vulnerabilities

### DIFF
--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -25,5 +25,6 @@
 		".otf" : "application/x-font-opentype",
 		".ttf" : "application/x-font-truetype"
 	},
+	"restrictServerTree": true,
 	"timeout": 120000
 }

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -13,7 +13,7 @@
 		"X-Content-Type-Options": "nosniff",
 		"Cache-Control": "no-cache, no-store, must-revalidate",
 		"Pragma": "no-cache",
-		"Content-Security-Policy": "default-src 'self' localhost:8080; script-src 'unsafe-inline' localhost:8080; font-src *",
+		"Content-Security-Policy": "default-src 'self' 'unsafe-inline'; font-src 'self' 'unsafe-inline' fonts.gstatic.com; connect-src 'self' http://localhost:9090/ ws://localhost:9090/;",
 		"X-XSS-Protection": 1
 	},
 	"mimeTypes" : {

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -13,6 +13,7 @@
 		"X-Content-Type-Options": "nosniff",
 		"Cache-Control": "no-cache, no-store, must-revalidate",
 		"Pragma": "no-cache",
+		"Content-Security-Policy": "default-src 'self'",
 		"X-XSS-Protection": 1
 	},
 	"mimeTypes" : {

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -13,7 +13,7 @@
 		"X-Content-Type-Options": "nosniff",
 		"Cache-Control": "no-cache, no-store, must-revalidate",
 		"Pragma": "no-cache",
-		"Content-Security-Policy": "default-src 'self'",
+		"Content-Security-Policy": "default-src 'self' localhost:8080; script-src 'unsafe-inline' localhost:8080; font-src *",
 		"X-XSS-Protection": 1
 	},
 	"mimeTypes" : {

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -81,7 +81,7 @@ function getServerHeaders(headers) {
 
 function sendFile(fileRequested, req, res) {
 	fs.open(fileRequested, "r", (err, fd) => {	
-		if (err) sendError(req, res, 500, err);
+		if (err) (err.code === "ENOENT") ? sendError(req, res, 404, "Path Not Found.") : sendError(req, res, 500, err);
 		else {
 			access.info(`Sending: ${fileRequested}`);
 			let mime = conf.mimeTypes[path.extname(fileRequested)];

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -58,6 +58,10 @@ function handleRequest(req, res) {
 	let pathname = url.parse(req.url).pathname;
 	let fileRequested = `${path.resolve(conf.webroot)}/${pathname}`;
 
+	// don't allow reading outside webroot
+	if (!isSubdirectory(fileRequested, conf.webroot))
+		{sendError(req, res, 404, "Path Not Found."); return;}
+
 	// don't allow reading the server tree, if requested
 	if (conf.restrictServerTree && isSubdirectory(path.dirname(fileRequested), __dirname)) 
 		{sendError(req, res, 404, "Path Not Found."); return;}


### PR DESCRIPTION
### Restrict server tree access by default
- Added `"restrictServerTree": true` to `httpd.conf`

### Better error handling
- Prevent exposing sensitive data to user
- **Issue:**
  - File path exposed to user when requested directory does not contain an index file
  - Request:
  `GET http://localhost:8080/apps`
  - Response:
  `500 Error: ENOENT: no such file or directory, open '/home/arpit/Documents/Playground/monkshu/frontend//apps/index.html'`
- **Fix:**
  - Sending 404 when requested directory does not contain an index file
  - Request:
  `GET http://localhost:8080/apps`
  - Response:
  `404 Path Not Found.`

### Add in Content-Security-Policy HTTP header
- Add in `Content-Security-Policy` header to `httpdHeaders`

### Restrict reading outside webroot
- Restricted reading files outside webroot