### PR TITLE
Fix for HTTPS server and options

### DIFF
--- a/backend/server/lib/http_server.js
+++ b/backend/server/lib/http_server.js
@@ -4,17 +4,19 @@
  */
 
 const http = require("http");
+const https = require("https");
+const fs = require("fs");
 const conf = require(`${CONSTANTS.HTTPDCONF}`);
 
 exports.initSync = initSync;
 
-function initSync(port, host="::") {
-	let options = conf.ssl ? {pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase} : null;
-	
+function initSync(port, host = "::") {
+	const options = conf.ssl ? { pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase } : null;
+
 	/* create HTTP/S server */
 	LOG.info(`Attaching socket listener on ${host}:${port}`);
-	let listener = (_req, res) => Object.keys(conf.headers).forEach(header => res.setHeader(header, conf.headers[header]));
-	let server = options ? http.createServer(options, listener) : http.createServer(listener);
+	const listener = (_req, res) => Object.keys(conf.headers).forEach(header => res.setHeader(header, conf.headers[header]));
+	const server = options ? https.createServer(options, listener) : http.createServer(listener);
 	server.timeout = conf.timeout;
 	exports.connection = server.listen(port, host);
 }


### PR DESCRIPTION
## Fixes made:

- Add in missing `fs` module
  - enables use of `readFileSync` in `options` definition
- Create the HTTPS server using `https` module
  - enables the use of SSL `options` in creating server


## Other changes:

- Replaced `let` with `const`