### PR TITLE
Add in GZIP support

### DIFF
--- a/backend/server/conf/httpd.json
+++ b/backend/server/conf/httpd.json
@@ -1,9 +1,10 @@
 {
-"timeout": 120000,
-"ssl": false,
-"headers": {
-    "Access-Control-Allow-Origin":"*"
-},
-"pfxPath": "<path to PFX (.key) File>",
-"pfxPassphrase": "<passphrase for the pfx file>"
+    "timeout": 120000,
+    "ssl": false,
+    "enableGZIPEncoding": false,
+    "headers": {
+        "Access-Control-Allow-Origin": "*"
+    },
+    "pfxPath": "<path to PFX (.key) File>",
+    "pfxPassphrase": "<passphrase for the pfx file>"
 }

--- a/backend/server/lib/http_server.js
+++ b/backend/server/lib/http_server.js
@@ -15,8 +15,32 @@ function initSync(port, host = "::") {
 
 	/* create HTTP/S server */
 	LOG.info(`Attaching socket listener on ${host}:${port}`);
-	const listener = (_req, res) => Object.keys(conf.headers).forEach(header => res.setHeader(header, conf.headers[header]));
+	const listener = (req, res) => {
+		Object.keys(conf.headers).forEach(header => res.setHeader(header, conf.headers[header]));
+		const acceptEncodingHeader = req.headers["accept-encoding"] || "";
+		if (conf.enableGZIPEncoding && acceptEncodingHeader.includes("gzip")) { enableGZIPEncoding(req, res); }
+	};
 	const server = options ? https.createServer(options, listener) : http.createServer(listener);
 	server.timeout = conf.timeout;
 	exports.connection = server.listen(port, host);
 }
+
+const enableGZIPEncoding = (_req, res) => {
+	const zlib = require("zlib");
+
+	/* bind response methods */
+	const _writeHead = res.writeHead.bind(res);
+	const _write = res.write.bind(res);
+	const _end = res.end.bind(res);
+
+	/* override response methods */
+	res.writeHead = (statusCode, headers) => _writeHead.apply(res, [statusCode, { ...headers, "Content-Encoding": "gzip" }]);
+	res.write = (data) => {
+		zlib.gzip(data, (error, encodedData) => {
+			if (error) { LOG.error(error); return; }		// do not end response; allow timeout
+			_write.apply(res, [encodedData]);
+			_end.apply(res);
+		})
+	};
+	res.end = () => undefined;		// prevent premature res.end call
+};

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -1,13 +1,14 @@
 {
-	"port" : 8080,
-	"host" : "::",
-	"webroot" : "./../",
-	"logdir" : "./logs",
-	"libdir" : "./lib",
-	"accesslog" : "./logs/access.log.json",
-	"errorlog" : "./logs/error.log.json",
-	"indexfile" : "index.html",
+	"port": 8080,
+	"host": "::",
+	"webroot": "./../",
+	"logdir": "./logs",
+	"libdir": "./lib",
+	"accesslog": "./logs/access.log.json",
+	"errorlog": "./logs/error.log.json",
+	"indexfile": "index.html",
 	"ssl": false,
+	"enableGZIPEncoding": false,
 	"pfxPath": "<path to PFX (.key) File>",
 	"pfxPassphrase": "<passphrase for the pfx file>",
 	"httpdHeaders": {
@@ -19,15 +20,15 @@
 		"Content-Security-Policy": "default-src 'self' 'unsafe-inline'; font-src 'self' 'unsafe-inline' fonts.gstatic.com; connect-src 'self' http://localhost:9090/ ws://localhost:9090/;",
 		"X-XSS-Protection": 1
 	},
-	"mimeTypes" : {
-		".html" : "text/html",
-		".htm" : "text/html",
-		".thtml" : "text/html",
-		".css" : "text/css",
-		".js" : "text/javascript",
-		".mjs" : "text/javascript",
-		".otf" : "application/x-font-opentype",
-		".ttf" : "application/x-font-truetype"
+	"mimeTypes": {
+		".html": "text/html",
+		".htm": "text/html",
+		".thtml": "text/html",
+		".css": "text/css",
+		".js": "text/javascript",
+		".mjs": "text/javascript",
+		".otf": "application/x-font-opentype",
+		".ttf": "application/x-font-truetype"
 	},
 	"restrictServerTree": true,
 	"timeout": 120000


### PR DESCRIPTION
## Summary:

- Add in gzip support for backend HTTP transport server
- Add in gzip support for frontend main server
- Both are configurable via `enableGZIPEncoding` key in respective HTTPD confs