### PR TITLE
Pfx passphrase changes

### DIFF
--- a/backend/server/conf/crypt.json
+++ b/backend/server/conf/crypt.json
@@ -1,4 +1,0 @@
-{
-    "key":"21887als2141rwq294938jwkj3029rqsnj",
-    "crypt_algo":"aes-256-ctr"
-}

--- a/backend/server/conf/httpd.json
+++ b/backend/server/conf/httpd.json
@@ -10,7 +10,7 @@
         "Access-Control-Max-Age": 86400
     },
     "pfxPath": "<path to PFX (.key) File>",
-    "pfxPassphrase": "<passphrase for the pfx file>",
+    "pfxPassphrase": "<encrypted passphrase for the pfx file>",
     "host" : "0.0.0.0",
     "port" : 9090
 }

--- a/backend/server/lib/apiregistry_extensions/encryptedbodydecoderencoder.js
+++ b/backend/server/lib/apiregistry_extensions/encryptedbodydecoderencoder.js
@@ -4,7 +4,7 @@
  * 
  * Encrypted data decoder
  */
-const crypt = require(CONSTANTS.LIBDIR+"/crypt.js");
+const crypt = require(SHARED_CONSTANTS.LIBDIR+"/crypt.js");
 const utils = require(CONSTANTS.LIBDIR+"/utils.js");
 
 function decodeIncomingData(apiregentry, _url, data, headers, _servObject) {

--- a/backend/server/lib/constants.js
+++ b/backend/server/lib/constants.js
@@ -6,9 +6,6 @@
 const path = require("path");
 const rootdir = path.resolve(__dirname+"/../");
 
-exports.SHARED_LIBDIR = path.resolve(rootdir + "/../../shared/lib");
-if (!global.SHARED_CONSTANTS) global.SHARED_CONSTANTS = require(`${exports.SHARED_LIBDIR}/constants.js`);
-
 exports.ROOTDIR = rootdir;
 exports.APPROOTDIR = rootdir+"/../apps";
 exports.LIBDIR = rootdir+"/lib";
@@ -26,6 +23,10 @@ exports.MAX_LOG = 1024;
 
 /* Shared namespace */
 exports.SHARED_PROC_MEMORY = {};
+
+/* Shared constants */
+exports.SHARED_LIBDIR = path.resolve(rootdir + "/../../shared/lib");
+if (!global.SHARED_CONSTANTS) global.SHARED_CONSTANTS = require(`${exports.SHARED_LIBDIR}/constants.js`);
 
 /* Result objects */
 exports.FALSE_RESULT = {"result":false};

--- a/backend/server/lib/constants.js
+++ b/backend/server/lib/constants.js
@@ -6,6 +6,9 @@
 const path = require("path");
 const rootdir = path.resolve(__dirname+"/../");
 
+exports.SHARED_LIBDIR = path.resolve(rootdir + "/../../shared/lib");
+if (!global.SHARED_CONSTANTS) global.SHARED_CONSTANTS = require(`${exports.SHARED_LIBDIR}/constants.js`);
+
 exports.ROOTDIR = rootdir;
 exports.APPROOTDIR = rootdir+"/../apps";
 exports.LIBDIR = rootdir+"/lib";
@@ -16,7 +19,6 @@ exports.TRANSPORT = rootdir + "/conf/transport.json";
 exports.CLUSTERCONF = rootdir+"/conf/cluster.json";
 exports.LOGSCONF = rootdir+"/conf/log.json";
 exports.LOGMAIN = rootdir+"/logs/server.log.ndjson";
-exports.CRYPTCONF = rootdir+"/conf/crypt.json";
 exports.HTTPDCONF = rootdir + "/conf/httpd.json";
 exports.BLACKBOARDCONF = rootdir + "/conf/blackboard.json";
 exports.RELEASEFILE = rootdir+"/../../RELEASE";

--- a/backend/server/lib/http_server.js
+++ b/backend/server/lib/http_server.js
@@ -7,11 +7,12 @@ const fs = require("fs");
 const http = require("http");
 const https = require("https");
 const conf = require(`${CONSTANTS.HTTPDCONF}`);
+const crypt = require(CONSTANTS.LIBDIR + "/crypt.js");
 const gzipAsync = require("util").promisify(require("zlib").gzip);
 const HEADER_ERROR = {"content-type": "text/plain", "content-encoding":"identity"};
 
 function initSync() {
-	const options = conf.ssl ? { pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase } : null;
+	const options = conf.ssl ? { pfx: fs.readFileSync(conf.pfxPath), passphrase: crypt.decrypt(conf.pfxPassphrase) } : null;
 
 	/* create HTTP/S server */
 	let host = conf.host || "::";

--- a/backend/server/lib/http_server.js
+++ b/backend/server/lib/http_server.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const http = require("http");
 const https = require("https");
 const conf = require(`${CONSTANTS.HTTPDCONF}`);
-const crypt = require(CONSTANTS.LIBDIR + "/crypt.js");
+const crypt = require(SHARED_CONSTANTS.LIBDIR + "/crypt.js");
 const gzipAsync = require("util").promisify(require("zlib").gzip);
 const HEADER_ERROR = {"content-type": "text/plain", "content-encoding":"identity"};
 

--- a/backend/server/lib/rest.js
+++ b/backend/server/lib/rest.js
@@ -16,7 +16,7 @@ const http = require("http");
 const zlib = require("zlib");
 const https = require("https");
 const utils = require(CONSTANTS.LIBDIR + "/utils.js");
-const crypt = require(CONSTANTS.LIBDIR + "/crypt.js");
+const crypt = require(SHARED_CONSTANTS.LIBDIR + "/crypt.js");
 
 const fs = require("fs");
 const path = require("path");

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -10,7 +10,7 @@
 	"ssl": false,
 	"enableGZIPEncoding": true,
 	"pfxPath": "<path to PFX (.key) File>",
-	"pfxPassphrase": "<passphrase for the pfx file>",
+	"pfxPassphrase": "<encrypted passphrase for the pfx file>",
 	"httpdHeaders": {
 		"Server": "Monkshu HTTPD",
 		"X-XSS-Protection": 1,

--- a/frontend/server/conf/httpd.readme
+++ b/frontend/server/conf/httpd.readme
@@ -14,7 +14,7 @@
 	"ssl": false, <-- Set to true for HTTPS
 	"enableGZIPEncoding": true, <-- Everything will be gzip encoded if MIME supports it (see mime section)
 	"pfxPath": "<path to PFX (.key) File>", <-- For HTTPS the path to the certificate PFX file
-	"pfxPassphrase": "<passphrase for the pfx file>", <-- For HTTPS the passphrase for certificate PFX file
+	"pfxPassphrase": "<encrypted passphrase for the pfx file>", <-- For HTTPS the encrypted passphrase for certificate PFX file
 	"httpdHeaders": { <-- Hardcode these headers in every response
 		"Server": "Monkshu HTTPD",
 		"X-XSS-Protection": 1,

--- a/frontend/server/lib/constants.js
+++ b/frontend/server/lib/constants.js
@@ -1,0 +1,14 @@
+/**  
+ * (C) 2021 TekMonks. All rights reserved.
+ * 
+ */
+
+const path = require("path");
+const rootdir = path.resolve(__dirname + "/../");
+
+exports.ROOTDIR = rootdir;
+exports.CONFDIR = rootdir + "/conf";
+
+/* Shared constants */
+exports.SHARED_LIBDIR = path.resolve(rootdir + "/../../shared/lib");
+if (!global.SHARED_CONSTANTS) global.SHARED_CONSTANTS = require(`${exports.SHARED_LIBDIR}/constants.js`);

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -5,12 +5,15 @@
  * License: See enclosed file.
  */
 
+global.CONSTANTS = require(__dirname + "/lib/constants.js");
+
 const fs = require("fs");
 const url = require("url");
 const zlib = require("zlib");
 const path = require("path");
 const http = require("http");
 const https = require("https");
+const crypt = require(SHARED_CONSTANTS.LIBDIR + "/crypt.js");
 let access; let error;
 
 exports.bootstrap = bootstrap;
@@ -24,7 +27,7 @@ function bootstrap() {
 
 	/* Start HTTP/S server */
 	const listener = (req, res) => { try{_handleRequest(req, res);} catch(e){error.error(e.stack?e.stack.toString():e.toString()); _sendError(req,res,500,e);} }
-	const options = conf.ssl ? {pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase} : null;
+	const options = conf.ssl ? {pfx: fs.readFileSync(conf.pfxPath), passphrase: crypt.decrypt(conf.pfxPassphrase)} : null;
 	const httpd = options ? https.createServer(options, listener) : http.createServer(listener);
 	httpd.setTimeout(conf.timeout);
 	httpd.listen(conf.port, conf.host||"::");
@@ -34,7 +37,7 @@ function bootstrap() {
 }
 
 function _initConfSync() {
-	global.conf = require(`${__dirname}/conf/httpd.json`);
+	global.conf = require(`${CONSTANTS.CONFDIR}/httpd.json`);
 
 	// normalize paths
 	conf.webroot = path.resolve(conf.webroot);	

--- a/shared/conf/crypt.json
+++ b/shared/conf/crypt.json
@@ -1,0 +1,4 @@
+{
+    "key": "21887als2141rwq294938jwkj3029rqsnj",
+    "crypt_algo": "aes-256-ctr"
+}

--- a/shared/lib/constants.js
+++ b/shared/lib/constants.js
@@ -1,0 +1,12 @@
+/**  
+ * (C) 2021 TekMonks. All rights reserved.
+ * 
+ */
+
+const path = require("path");
+const rootdir = path.resolve(__dirname + "/../");
+
+exports.ROOTDIR = rootdir;
+exports.LIBDIR = rootdir + "/lib";
+exports.CONFDIR = rootdir + "/conf";
+exports.CRYPTCONF = rootdir + "/conf/crypt.json";

--- a/shared/lib/crypt.js
+++ b/shared/lib/crypt.js
@@ -1,10 +1,12 @@
-/* 
- * (C) 2015 - 2018 TekMonks. All rights reserved.
+/**  
+ * (C) 2021 TekMonks. All rights reserved.
+ * 
  */
-if (!global.CONSTANTS) global.CONSTANTS = require(__dirname + "/constants.js");	// to support direct execution
+
+if (!global.SHARED_CONSTANTS) global.SHARED_CONSTANTS = require(__dirname + "/constants.js");	// to support direct execution
 
 const cryptmod = require("crypto");
-const crypt = require(CONSTANTS.CRYPTCONF);
+const crypt = require(SHARED_CONSTANTS.CRYPTCONF);
 
 function encrypt(text, key = crypt.key) {
 	const iv = Buffer.from(cryptmod.randomBytes(16)).toString("hex").slice(0, 16);


### PR DESCRIPTION
#### Fixes issue #25 
---
## Changes:
- Move `crypt` resources to a shared directory
- Introduce `SHARED_CONSTANTS` in frontend and backend
- Update in backend modules to require `crypt` from `shared/lib/crypt.js`
- Changes for the backend to use encrypted pfx passphrase
- Changes for the frontend to use encrypted pfx passphrase