### PR TITLE
PFX Passphrase should be encrypted

### DIFF
--- a/backend/server/conf/httpd.json
+++ b/backend/server/conf/httpd.json
@@ -10,7 +10,7 @@
         "Access-Control-Max-Age": 86400
     },
     "pfxPath": "<path to PFX (.key) File>",
-    "pfxPassphrase": "<passphrase for the pfx file>",
+    "pfxPassphrase": "<encrypted passphrase for the pfx file>",
     "host" : "0.0.0.0",
     "port" : 9090
 }

--- a/backend/server/lib/crypt.js
+++ b/backend/server/lib/crypt.js
@@ -25,15 +25,15 @@ function decrypt(text, key = crypt.key) {
 	return decrypted;
 }
 
+module.exports = { encrypt, decrypt };
+
 if (require.main === module) {
 	const args = process.argv.slice(2);
 
-	if (args.length < 2) {
+	if (args.length < 2 || !module.exports[args[0]]) {
 		console.log("Usage: crypt <encyrpt|decrypt> <text to encrypt or decrypt>");
 		process.exit(1);
 	}
 
-	console.log(eval(args[0])(args[1]));
+	console.log(module.exports[args[0]](args[1]));
 }
-
-module.exports = { encrypt, decrypt };

--- a/backend/server/lib/http_server.js
+++ b/backend/server/lib/http_server.js
@@ -7,11 +7,12 @@ const fs = require("fs");
 const http = require("http");
 const https = require("https");
 const conf = require(`${CONSTANTS.HTTPDCONF}`);
+const crypt = require(`${CONSTANTS.LIBDIR}/crypt.js`);
 const gzipAsync = require("util").promisify(require("zlib").gzip);
 const HEADER_ERROR = {"content-type": "text/plain", "content-encoding":"identity"};
 
 function initSync() {
-	const options = conf.ssl ? { pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase } : null;
+	const options = conf.ssl ? { pfx: fs.readFileSync(conf.pfxPath), passphrase: crypt.decrypt(conf.pfxPassphrase) } : null;
 
 	/* create HTTP/S server */
 	let host = conf.host || "::";

--- a/frontend/server/conf/httpd.json
+++ b/frontend/server/conf/httpd.json
@@ -10,7 +10,7 @@
 	"ssl": false,
 	"enableGZIPEncoding": true,
 	"pfxPath": "<path to PFX (.key) File>",
-	"pfxPassphrase": "<passphrase for the pfx file>",
+	"pfxPassphrase": "<encrypted passphrase for the pfx file>",
 	"httpdHeaders": {
 		"Server": "Monkshu HTTPD",
 		"X-XSS-Protection": 1,

--- a/frontend/server/conf/httpd.readme
+++ b/frontend/server/conf/httpd.readme
@@ -14,7 +14,7 @@
 	"ssl": false, <-- Set to true for HTTPS
 	"enableGZIPEncoding": true, <-- Everything will be gzip encoded if MIME supports it (see mime section)
 	"pfxPath": "<path to PFX (.key) File>", <-- For HTTPS the path to the certificate PFX file
-	"pfxPassphrase": "<passphrase for the pfx file>", <-- For HTTPS the passphrase for certificate PFX file
+	"pfxPassphrase": "<encrypted passphrase for the pfx file>", <-- For HTTPS the encrypted passphrase for certificate PFX file
 	"httpdHeaders": { <-- Hardcode these headers in every response
 		"Server": "Monkshu HTTPD",
 		"X-XSS-Protection": 1,

--- a/frontend/server/lib/crypt.js
+++ b/frontend/server/lib/crypt.js
@@ -1,0 +1,20 @@
+/**
+ * (C) 2021 TekMonks. All rights reserved. 
+ * 
+ */
+
+const path = require("path");
+const monkshu_root = path.resolve(__dirname + "/../../../");
+
+module.exports = { ...require(`${monkshu_root}/backend/server/lib/crypt.js`) };
+
+if (require.main === module) {
+	const args = process.argv.slice(2);
+
+	if (args.length < 2 || !module.exports[args[0]]) {
+		console.log("Usage: crypt <encyrpt|decrypt> <text to encrypt or decrypt>");
+		process.exit(1);
+	}
+
+	console.log(module.exports[args[0]](args[1]));
+}

--- a/frontend/server/server.js
+++ b/frontend/server/server.js
@@ -22,9 +22,11 @@ function bootstrap() {
 	_initConfSync();
 	_initLogsSync();
 
+	const crypt = require(`${conf.libdir}/crypt.js`);
+
 	/* Start HTTP/S server */
 	const listener = (req, res) => { try{_handleRequest(req, res);} catch(e){error.error(e.stack?e.stack.toString():e.toString()); _sendError(req,res,500,e);} }
-	const options = conf.ssl ? {pfx: fs.readFileSync(conf.pfxPath), passphrase: conf.pfxPassphrase} : null;
+	const options = conf.ssl ? {pfx: fs.readFileSync(conf.pfxPath), passphrase: crypt.decrypt(conf.pfxPassphrase)} : null;
 	const httpd = options ? https.createServer(options, listener) : http.createServer(listener);
 	httpd.setTimeout(conf.timeout);
 	httpd.listen(conf.port, conf.host||"::");


### PR DESCRIPTION
#### Fixes Issue #25 
#### Incorporates feedback from PR #26 

## Changes:
- PFX Passphrases should now be encrypted
- Uses code equivalent of a symlink as suggested
- No need for shared constants as per updated design
- Updated `crypt.js` to not use `eval` when executing directly
---
- This is a separate pull for encrypting pfx passphrase
- Any changes required on this are open for discussion