### PR TITLE
Support listening on IPv6 host out of the box

### DIFF
--- a/backend/server/conf/httpd.json
+++ b/backend/server/conf/httpd.json
@@ -11,6 +11,6 @@
     },
     "pfxPath": "<path to PFX (.key) File>",
     "pfxPassphrase": "<encrypted passphrase for the pfx file>",
-    "host" : "0.0.0.0",
+    "host" : "::",
     "port" : 9090
 }


### PR DESCRIPTION
## Changes:
- Update `host` in `backend/server/conf/httpd.json` from `"0.0.0.0"` to `"::"`