### PR TITLE
Added edit submenus on Mac

### DIFF
--- a/desktop/framework/main.js
+++ b/desktop/framework/main.js
@@ -14,7 +14,8 @@ const { app, BrowserWindow, Menu, shell, Tray, ipcMain, nativeImage } = require(
 const isMac = process.platform === "darwin";
 const menuTemplate = [
 	...(isMac ? [{label: app.name, submenu: [{ role: "about" }, { type: "separator" }, { role: "services" }, 
-		{ type: "separator" }, { role: "hide" }, { role: "hideOthers" }, { role: "unhide" }, 
+		{ type: "separator" }, { role: "hide" }, { role: "hideOthers" }, { role: "unhide" },
+		{ type: 'separator' }, { role: 'cut' }, { role: 'copy' }, { role: 'paste' }, { role: 'delete' }, { role: 'selectall' },
 		{ type: "separator" }, { role: "quit" }]}] : []),
 	{label: "File", submenu: [{ role: "quit" }]},
 	{role: "help", submenu: [{label: "Learn More", click: async () => {shell.openExternal(appconf.homepage)}}]}


### PR DESCRIPTION
In a desktop application on Mac, paste from the clipboard does not work.
Added edit submenus on Mac to fix it.