### PR TITLE
[FIX] MEM_KEY undefined in constants.js | used in Monkshu inbuilt SSE

### DIFF
--- a/backend/server/apis/appevents.js
+++ b/backend/server/apis/appevents.js
@@ -12,9 +12,9 @@
 const SERVER_API_SSE_EVENT = "_org_monkshu_api_sse_event_";
 
 exports.doSSE = async (jsonReq, sseEventSender) => {
-    const memory = CLUSTER_MEMORY.get(CONSTANTS.MEM_KEY+jsonReq.clientid, {});
+    const memory = CLUSTER_MEMORY.get(CONSTANTS.SSE_MEM_KEY+jsonReq.clientid, {});
     for (const [requestid, response] of Object.entries(memory)) {
-        delete memory[requestid]; await CLUSTER_MEMORY.set(CONSTANTS.MEM_KEY+jsonReq.clientid, memory, true);
+        delete memory[requestid]; await CLUSTER_MEMORY.set(CONSTANTS.SSE_MEM_KEY+jsonReq.clientid, memory, true);
         sseEventSender({event: SERVER_API_SSE_EVENT, id: Date.now(), data:{requestid, response}});
     }
 }

--- a/backend/server/lib/constants.js
+++ b/backend/server/lib/constants.js
@@ -63,6 +63,9 @@ exports.API_MANAGER_ENCODERS_CONF_APPS = "conf/apiregistry.encoders.json";
 exports.API_MANAGER_SECURITYCHECKERS_CONF_APPS = "conf/apiregistry.securitycheckers.json";
 exports.API_MANAGER_HEADERMANAGERS_CONF_APPS = "conf/apiregistry.headermanagers.json";
 
+/* Monkshu's SSE Constants */
+exports.SSE_MEM_KEY = "__org_monkshu_sse_mem_key_";
+
 function overrideConstants() {
     const _isPath = key => { for (const ending of ["dir", "conf", "apiregistry"]) if (key.toLowerCase().endsWith(ending)) return true; return false;}
     const currentConstants = {...module.exports}; for (const [key, value] of Object.entries(currentConstants))

--- a/backend/server/server.js
+++ b/backend/server/server.js
@@ -271,7 +271,7 @@ function _checkIfResponseViaSSEAPIRequest(apiconf, headers, jsonObj) {
 }
 
 async function _runAPIAndSetSSEMemory(apiModule, requestid, jsonObj, servObject, headers, url, apiconf) {
-	const clientMemoryKey = CONSTANTS.MEM_KEY+jsonObj.clientid;
+	const clientMemoryKey = CONSTANTS.SSE_MEM_KEY+jsonObj.clientid;
 	const clientMemory = CLUSTER_MEMORY.get(clientMemoryKey, {});
 	try {
 		const respObj = await apiModule.doService(jsonObj, servObject, headers, url, apiconf);


### PR DESCRIPTION
**Changes Made:**
- Renamed the MEM_KEY to SSE_MEM_KEY since the same is used only for  Monkshu's inbuilt SSE event emitting.
- exported the SSE_MEM_KEY inside the constant.js.

Why the same was working earlier:
- Inside `server.js's` function `_runAPIAndSetSSEMemory` and Monkshu's api' `appevents`. Import for MEM_KEY was coming as **undefined** and we were concatenating the CONSTANTS.MEM_KEY with jsonreq.client_id. Thus, the result of both was becoming = **undefinedclient_id**.

Note: Screenshot of testing for the fix has been attached in the mantis link Below.

**Mantis Link** - https://tekmonks.mantishub.io/app/issues/6625