### PR TITLE
[FEATURE] add in process env support in crypt module

### DIFF
--- a/backend/server/lib/crypt.js
+++ b/backend/server/lib/crypt.js
@@ -4,7 +4,23 @@
 if (!global.CONSTANTS) global.CONSTANTS = require(__dirname + "/constants.js");	// to support direct execution
 
 const cryptmod = require("crypto");
-const crypt = require(CONSTANTS.CRYPTCONF);
+const cryptConf = require(CONSTANTS.CRYPTCONF);
+
+/**
+ * Resolves env:VARIABLE_NAME values from the named environment variable (throws if unset), returns all other values as is.
+ * @param {string or object} val The configuration value to resolve
+ * @returns The resolved value from environment variable's set
+ */
+const _resolveConf = val => {
+	if(typeof val!=="string" || !val.startsWith("env:")) return val; 
+	const envValue = process.env[val.substring(4)]; 
+	if(!envValue) throw (`Environment variable ${val.substring(4)} not set or crypt conf is not configured properly`);
+	return envValue;
+}
+
+// Load Configuration in memory.
+const crypt = {};
+for(const key in cryptConf) crypt[key] = _resolveConf(cryptConf[key]);
 
 /**
  * Encrypts the given string or Buffer
@@ -69,7 +85,7 @@ function getDecipher(key = crypt.key, iv = Buffer.alloc(16, 0)) {
 	return decipher;
 }
 
-module.exports = { encrypt, decrypt, getCipher, getDecipher, main }
+module.exports = { encrypt, decrypt, getCipher, getDecipher, resolveConf: _resolveConf, main }
 
 if (require.main === module) main();
 function main() {


### PR DESCRIPTION
**Updates:**
- `conf/crypt.json` values can now be of the form `env:VARIABLE_NAME`, in which
  case the value is read from that environment variable at module load. Plain literal values work unchanged. If the conf names a variable that is not set, the module throws at load and the server refuses to start.
- **Exported resolveConf** so that Monkshu based applications can resolve `env:` values in their own app-specific JSON confs from environment variables using the same mechanism. 
- Totally backward compatible: existing confs with plain-text keys behave exactly as before, and all exported functions (encrypt, decrypt, getCipher, getDecipher) keep their existing signatures and behavior - current
  applications using them need no changes.
 - Testing screenshots have been attached in the mantis given below.
 
 **Mantis Link** - https://tekmonks.mantishub.io/app/issues/6764