### PR TITLE
[FEATURE] added function for env resolution for conf | resolves crypt…

### DIFF
--- a/backend/server/lib/crypt.js
+++ b/backend/server/lib/crypt.js
@@ -4,7 +4,12 @@
 if (!global.CONSTANTS) global.CONSTANTS = require(__dirname + "/constants.js");	// to support direct execution
 
 const cryptmod = require("crypto");
-const crypt = require(CONSTANTS.CRYPTCONF);
+const utils = require(`${CONSTANTS.LIBDIR}/utils.js`);
+const cryptConf = require(CONSTANTS.CRYPTCONF);
+
+// Load Configuration in memory, resolving env:VARIABLE_NAME values from the environment.
+const crypt = {};
+for(const key in cryptConf) crypt[key] = utils.resolveConf(cryptConf[key]);
 
 /**
  * Encrypts the given string or Buffer

--- a/backend/server/lib/utils.js
+++ b/backend/server/lib/utils.js
@@ -715,6 +715,18 @@ function exec(command, args, encoding, escapeArgs=true, inShell=true, quoterChar
 }
 
 /**
+ * Resolves env:VARIABLE_NAME values from the named environment variable (throws if unset), returns all other values as is.
+ * @param {string or object} val The configuration value to resolve
+ * @returns The resolved value from environment variable's set
+ */
+const resolveConf = val => {
+    if (typeof val !== "string" || !val.startsWith("env:")) return val;
+    const envValue = process.env[val.substring(4)];
+    if (!envValue) throw (`Environment variable ${val.substring(4)} not set or conf is not configured properly`);
+    return envValue;
+}
+
+/**
  * Checks if the objects are deep equal.
  * @param {object} objA Object A
  * @param {object} objB Object B
@@ -741,4 +753,4 @@ module.exports = { parseBoolean, getDateTime, queryToObject, escapedSplit, getTi
     watchFile, clone, walkFolder, rmrf, getObjProperty, setObjProperty, setObjPropertyRecursive, requireWithDebug, generateUUID, 
     createAsyncFunction, createSyncFunction, getLocalIPs, promiseExceptionToBoolean, createDirectory, exists, 
     convertToUnixPathEndings, isObject, hashObject, stringToBase64, base64ToString, objectMemSize, zipFolder, 
-    gzipFile, dnsResolve, exec, areObjectsEqual };
+    gzipFile, dnsResolve, exec, areObjectsEqual, resolveConf };


### PR DESCRIPTION
**Updates:**
- Adds function `resolveConf` in `utils.js` for resolving environment variable based configurations for Monkshu and Monkshu-based applications + backward compatible with existing plain text based confs (non env: values are returned as-is).
- Crypt module's conf is resolved once at startup (module load) - To save re-resolving the env variable on every encrypt/decrypt call (used inside monkshu) , and to avoid touching all four crypto functions.

**Usage:**
- Write the crypt key or any configuration in this format:
```
"key": "env:MONKSHU_CRYPT_KEY"
```
- Import and call the resolveConf function while passing in `env:MONKSHU_CRYPT_KEY` + environment variable already set. If not, gives an error.

**Mantis Link:** - https://tekmonks.mantishub.io/app/issues/6764