### PR TITLE
[FEATURE] env support for configuration files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Monkshu environment variables — copy to .env and fill in real values.
+# Any conf value in the format "env:VARIABLE_NAME" is resolved from these
+# at module load via Monkshu's utility function. Unset variables fail startup.
+# Local dev: node --env-file=.env server.js   (Node >= 20.6)
+# Production: Update systemd service file with EnvironmentFile=/path/to/.env
+
+# backend/server/conf/crypt.json -> "key": "env:MONKSHU_CRYPT_KEY"
+# MONKSHU_CRYPT_KEY=your-crypt-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ backend/server/conf/constants.json
 frontend/webpack/*
 frontend/index.mjs
 frontend/index.js
+.env

--- a/backend/server/lib/crypt.js
+++ b/backend/server/lib/crypt.js
@@ -4,7 +4,7 @@
 if (!global.CONSTANTS) global.CONSTANTS = require(__dirname + "/constants.js");	// to support direct execution
 
 const cryptmod = require("crypto");
-const crypt = require(CONSTANTS.CRYPTCONF);
+const crypt = require(`${CONSTANTS.LIBDIR}/utils.js`).loadAndResolveConf(CONSTANTS.CRYPTCONF);
 
 /**
  * Encrypts the given string or Buffer

--- a/backend/server/lib/utils.js
+++ b/backend/server/lib/utils.js
@@ -715,6 +715,27 @@ function exec(command, args, encoding, escapeArgs=true, inShell=true, quoterChar
 }
 
 /**
+ * Loads the given conf (JSON) file and returns it with all env:VARIABLE_NAME values resolved
+ * from the named environment variables (throws if one is unset), all other values are returned
+ * as is. Objects and arrays are resolved recursively.
+ * @param {string} path The path to the conf JSON file
+ * @returns The loaded configuration with all env values resolved
+ */
+function loadAndResolveConf(path) {
+    const _resolve = val => {
+        if (typeof val === "string" && val.startsWith("env:")) {
+            const envValue = process.env[val.substring(4)];
+            if (!envValue) throw (`Environment variable ${val.substring(4)} not set or conf is not configured properly`);
+            return envValue;
+        }
+        if (Array.isArray(val)) return val.map(_resolve);
+        if (isObject(val)) {const resolved = {}; for (const key in val) resolved[key] = _resolve(val[key]); return resolved;}
+        return val;
+    }
+    return _resolve(require(path));
+}
+
+/**
  * Checks if the objects are deep equal.
  * @param {object} objA Object A
  * @param {object} objB Object B
@@ -741,4 +762,4 @@ module.exports = { parseBoolean, getDateTime, queryToObject, escapedSplit, getTi
     watchFile, clone, walkFolder, rmrf, getObjProperty, setObjProperty, setObjPropertyRecursive, requireWithDebug, generateUUID, 
     createAsyncFunction, createSyncFunction, getLocalIPs, promiseExceptionToBoolean, createDirectory, exists, 
     convertToUnixPathEndings, isObject, hashObject, stringToBase64, base64ToString, objectMemSize, zipFolder, 
-    gzipFile, dnsResolve, exec, areObjectsEqual };
+    gzipFile, dnsResolve, exec, areObjectsEqual, loadAndResolveConf };


### PR DESCRIPTION
**Updates:**

- Adds `utils.loadAndResolveConf(path)` - loads a conf JSON and returns it with all `env:VARIABLE_NAME` values resolved from environment variables (recursive, nested objects/arrays included; throws at load if a variable is unset). Backward compatible, plain text conf values are returned as-is.
- Consumers make a single "load my conf" call, no per-module resolution loops.
- 

**Usage:**
- `"key": "env:MONKSHU_CRYPT_KEY"` in the conf, with the variable set in the process environment. 
- Use Monkshu Utility function `loadAndResolveConf ` to load the configuration file.

**Tested:** 
- crypt CLI encrypt/decrypt both
- fail-fast throw on unset variable 
- nested env: values resolve
- all other values pass through identical.